### PR TITLE
Added confirmations field in PaymentRequest

### DIFF
--- a/src/Response/Hydrator/Payment/PaymentRequest.php
+++ b/src/Response/Hydrator/Payment/PaymentRequest.php
@@ -23,6 +23,7 @@ class PaymentRequest extends Reflection
             'URI' => 'uri',
             'exp' => 'expires',
             'time' => 'time',
+            'confirmations' => 'confirmations',
         ]);
 
         $this->setNamingStrategy($namingStrategy);

--- a/src/Response/Model/Payment/PaymentRequest.php
+++ b/src/Response/Model/Payment/PaymentRequest.php
@@ -72,6 +72,11 @@ class PaymentRequest implements ResponseInterface
     private $time = 0;
 
     /**
+     * @var int
+     */
+    private $confirmations = null;
+
+    /**
      * Factory method
      *
      * @param array $data
@@ -242,6 +247,26 @@ class PaymentRequest implements ResponseInterface
     public function setTime($time)
     {
         $this->time = $time;
+
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getConfirmations()
+    {
+        return $this->confirmations;
+    }
+
+    /**
+     * @param int $confirmations
+     *
+     * @return PaymentRequest
+     */
+    public function setConfirmations($confirmations)
+    {
+        $this->confirmations = $confirmations;
 
         return $this;
     }


### PR DESCRIPTION
Status can be Paid without any confirmations. So be able to check the number of confirmations is nice.