### PR TITLE
replace :: `zendframework/zend-hydrator`=> laminas/laminas-hydrator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Composer
 /vendor/
 composer.lock
+composer.phar
 
 # IDE
 /.idea
@@ -11,3 +12,4 @@ test.php
 
 # Thanks macOS
 .DS_Store
+/nbproject

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "padrio/php-electrum-api",
+    "name": "uran1980/php-electrum-api",
     "description": "PHP wrapper for Electrum JSONRPC-API",
     "type": "library",
 	"keywords": ["electrum", "bitcoin", "payment", "jsonrpc", "api"],
@@ -15,6 +15,7 @@
         }
     ],
     "require": {
+        "php": "^7.3 || ~8.0.0",
         "laminas/laminas-hydrator": "~4.1.0"
     },
 	"autoload": {

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "zendframework/zend-hydrator": "^2.2"
+        "laminas/laminas-hydrator": "~4.1.0"
     },
 	"autoload": {
 		"psr-4": {

--- a/src/Request/AbstractMethod.php
+++ b/src/Request/AbstractMethod.php
@@ -4,8 +4,7 @@ namespace Electrum\Request;
 
 use Electrum\Client;
 use Electrum\Response\ResponseInterface;
-use Zend\Hydrator\Reflection as ReflectionHydrator;
-use Zend\Hydrator\Reflection;
+use Laminas\Hydrator\ReflectionHydrator;
 
 /**
  * @author Pascal Krason <p.krason@padr.io>
@@ -43,15 +42,15 @@ abstract class AbstractMethod
     /**
      * Hydrate returned api data into our custom response models
      *
-     * @param ResponseInterface $object
-     * @param array             $data
-     * @param null              $hydrator
+     * @param ResponseInterface       $object
+     * @param array                   $data
+     * @param ReflectionHydrator|null $hydrator
      *
      * @return ResponseInterface
      */
     public function hydrate(ResponseInterface $object, array $data, $hydrator = null)
     {
-        if(!$hydrator instanceof Reflection) {
+        if(!$hydrator instanceof ReflectionHydrator) {
             $hydrator = new ReflectionHydrator();
         }
 

--- a/src/Response/Hydrator/Payment/Amount.php
+++ b/src/Response/Hydrator/Payment/Amount.php
@@ -2,13 +2,13 @@
 
 namespace Electrum\Response\Hydrator\Payment;
 
-use Zend\Hydrator\NamingStrategy\MapNamingStrategy;
-use Zend\Hydrator\Reflection;
+use Laminas\Hydrator\NamingStrategy\MapNamingStrategy;
+use Laminas\Hydrator\ReflectionHydrator;
 
 /**
  * @author Pascal Krason <p.krason@padr.io>
  */
-class Amount extends Reflection
+class Amount extends ReflectionHydrator
 {
     /**
      * Initializes a new instance of this class.

--- a/src/Response/Hydrator/Payment/PaymentRequest.php
+++ b/src/Response/Hydrator/Payment/PaymentRequest.php
@@ -2,13 +2,13 @@
 
 namespace Electrum\Response\Hydrator\Payment;
 
-use Zend\Hydrator\NamingStrategy\MapNamingStrategy;
-use Zend\Hydrator\Reflection;
+use Laminas\Hydrator\NamingStrategy\MapNamingStrategy;
+use Laminas\Hydrator\ReflectionHydrator;
 
 /**
  * @author Pascal Krason <p.krason@padr.io>
  */
-class PaymentRequest extends Reflection
+class PaymentRequest extends ReflectionHydrator
 {
 
     public function __construct()

--- a/src/Response/Model/Payment/PaymentRequest.php
+++ b/src/Response/Model/Payment/PaymentRequest.php
@@ -10,15 +10,8 @@ use Electrum\Response\Hydrator\Payment\PaymentRequest as PaymentRequestHydrator;
  */
 class PaymentRequest implements ResponseInterface
 {
-
-    /**
-     *
-     */
     const STATUS_UNPAID = 'Pending';
 
-    /**
-     *
-     */
     const STATUS_EXPIRED = 'Expired';
 
     /**
@@ -26,9 +19,6 @@ class PaymentRequest implements ResponseInterface
      */
     const STATUS_UNKNOWN = 'Unknown';
 
-    /**
-     *
-     */
     const STATUS_PAID = 'Paid';
 
     /**


### PR DESCRIPTION
Replace deprecated old lib `zendframework/zend-hydrator` to `laminas/laminas-hydrator` to support `php7` and `php8` language versions